### PR TITLE
Remove unused field from range volume profile

### DIFF
--- a/DrawingTools/MyOrderFlowCustom/MofRangeVolumeProfile.cs
+++ b/DrawingTools/MyOrderFlowCustom/MofRangeVolumeProfile.cs
@@ -49,7 +49,6 @@ namespace NinjaTrader.NinjaScript.DrawingTools
         private SharpDX.Direct2D1.Brush buyBrushDX;
         private SharpDX.Direct2D1.Brush sellBrushDX;
         private SharpDX.Direct2D1.Brush textBrushDX;
-        private ChartControl ChartControl;
         private ChartBars ChartBars { get { return AttachedTo.ChartObject as ChartBars; } }
         private bool isLoading;
         private string loadingMessage = "Loading...";


### PR DESCRIPTION
## Summary
- remove unused field `ChartControl` from `MofRangeVolumeProfile`

## Testing
- `dotnet build -c Release MyOrderFlowCustom.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ab0d7c60832c87035bbd4938de45