### PR TITLE
Expose global HVN/LVN levels

### DIFF
--- a/DrawingTools/MyOrderFlowCustom/MofRangeVolumeProfile.cs
+++ b/DrawingTools/MyOrderFlowCustom/MofRangeVolumeProfile.cs
@@ -60,8 +60,28 @@ namespace NinjaTrader.NinjaScript.DrawingTools
 
         private readonly List<string> globalLineTags = new List<string>();
 
-        private static readonly Dictionary<string, List<double>> GlobalHvnLevels = new Dictionary<string, List<double>>();
-        private static readonly Dictionary<string, List<double>> GlobalLvnLevels = new Dictionary<string, List<double>>();
+        private static readonly Dictionary<string, List<double>> globalHvnLevels = new Dictionary<string, List<double>>();
+        private static readonly Dictionary<string, List<double>> globalLvnLevels = new Dictionary<string, List<double>>();
+
+        /// <summary>
+        /// Gets the global HVN levels keyed by instrument name.
+        /// </summary>
+        public static IReadOnlyDictionary<string, List<double>> GlobalHvnLevels => globalHvnLevels;
+
+        /// <summary>
+        /// Gets the global LVN levels keyed by instrument name.
+        /// </summary>
+        public static IReadOnlyDictionary<string, List<double>> GlobalLvnLevels => globalLvnLevels;
+
+        /// <summary>
+        /// Gets the detected HVN levels for this drawing.
+        /// </summary>
+        public IReadOnlyList<double> HvnLevels => hvnLevels;
+
+        /// <summary>
+        /// Gets the detected LVN levels for this drawing.
+        /// </summary>
+        public IReadOnlyList<double> LvnLevels => lvnLevels;
 
         #region OnStateChange
         protected override void OnStateChange()
@@ -181,8 +201,8 @@ namespace NinjaTrader.NinjaScript.DrawingTools
                 profile = newProfile;
                 if (UseGlobalLevels)
                 {
-                    GlobalHvnLevels[chartBars.Instrument.FullName] = new List<double>(hvnLevels);
-                    GlobalLvnLevels[chartBars.Instrument.FullName] = new List<double>(lvnLevels);
+                    globalHvnLevels[chartBars.Instrument.FullName] = new List<double>(hvnLevels);
+                    globalLvnLevels[chartBars.Instrument.FullName] = new List<double>(lvnLevels);
                 }
                 UpdateGlobalLines();
                 ForceRefresh();
@@ -265,8 +285,6 @@ namespace NinjaTrader.NinjaScript.DrawingTools
 
         private void RemoveGlobalLines()
         {
-            foreach (var tag in globalLineTags)
-                RemoveDrawObject(tag);
             globalLineTags.Clear();
         }
 
@@ -280,21 +298,11 @@ namespace NinjaTrader.NinjaScript.DrawingTools
             foreach (double price in hvnLevels)
             {
                 string tag = $"MOF_HVN_{Math.Round(price, decimals)}_{Tag}";
-                var line = Draw.HorizontalLine(this, tag, price, HvnStroke.Brush);
-                line.Stroke.Width = HvnStroke.Width;
-                line.Stroke.DashStyleHelper = HvnStroke.DashStyleHelper;
-                line.IsLocked = true;
-                line.IsGlobalDrawingTool = true;
                 globalLineTags.Add(tag);
             }
             foreach (double price in lvnLevels)
             {
                 string tag = $"MOF_LVN_{Math.Round(price, decimals)}_{Tag}";
-                var line = Draw.HorizontalLine(this, tag, price, LvnStroke.Brush);
-                line.Stroke.Width = LvnStroke.Width;
-                line.Stroke.DashStyleHelper = LvnStroke.DashStyleHelper;
-                line.IsLocked = true;
-                line.IsGlobalDrawingTool = true;
                 globalLineTags.Add(tag);
             }
         }
@@ -354,10 +362,10 @@ namespace NinjaTrader.NinjaScript.DrawingTools
                 }
                 if (ShowPoc) volProfileRenderer.RenderPoc(profile, PocStroke.BrushDX, PocStroke.Width, PocStroke.StrokeStyle);
                 if (ShowValueArea) volProfileRenderer.RenderValueArea(profile, ValueAreaStroke.BrushDX, ValueAreaStroke.Width, ValueAreaStroke.StrokeStyle);
-                var hvnList = UseGlobalLevels && GlobalHvnLevels.ContainsKey(ChartBars.Bars.Instrument.FullName) ?
-                    GlobalHvnLevels[ChartBars.Bars.Instrument.FullName] : hvnLevels;
-                var lvnList = UseGlobalLevels && GlobalLvnLevels.ContainsKey(ChartBars.Bars.Instrument.FullName) ?
-                    GlobalLvnLevels[ChartBars.Bars.Instrument.FullName] : lvnLevels;
+                var hvnList = UseGlobalLevels && globalHvnLevels.ContainsKey(ChartBars.Bars.Instrument.FullName) ?
+                    globalHvnLevels[ChartBars.Bars.Instrument.FullName] : hvnLevels;
+                var lvnList = UseGlobalLevels && globalLvnLevels.ContainsKey(ChartBars.Bars.Instrument.FullName) ?
+                    globalLvnLevels[ChartBars.Bars.Instrument.FullName] : lvnLevels;
                 if (ShowHvn && hvnList.Count > 0)
                     volProfileRenderer.RenderLevels(profile, hvnList, HvnStroke.BrushDX, HvnStroke.Width, HvnStroke.StrokeStyle);
                 if (ShowLvn && lvnList.Count > 0)

--- a/Indicators/MyOrderFlowCustom/MofGlobalLevelLines.cs
+++ b/Indicators/MyOrderFlowCustom/MofGlobalLevelLines.cs
@@ -1,0 +1,78 @@
+#region Using declarations
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Windows.Media;
+using NinjaTrader.Gui;
+using NinjaTrader.Gui.Chart;
+using NinjaTrader.Data;
+using NinjaTrader.NinjaScript;
+using NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom;
+using NinjaTrader.NinjaScript.DrawingTools;
+#endregion
+
+//This namespace holds Indicators in this folder and is required. Do not change it.
+namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
+{
+    /// <summary>
+    /// Example indicator that creates global horizontal lines from the levels
+    /// detected by <see cref="MofRangeVolumeProfile"/>.
+    /// </summary>
+    public class MofGlobalLevelLines : Indicator
+    {
+        private readonly HashSet<string> currentTags = new HashSet<string>();
+
+        protected override void OnStateChange()
+        {
+            if (State == State.SetDefaults)
+            {
+                Description  = "Draws global HVN/LVN lines calculated by MofRangeVolumeProfile.";
+                Name         = "MOF Global Level Lines";
+                IsOverlay    = true;
+                DisplayInDataBox = false;
+                DrawOnPricePanel = true;
+            }
+        }
+
+        protected override void OnBarUpdate()
+        {
+            string instrument = Instrument.FullName;
+            List<double> hvnList = null;
+            List<double> lvnList = null;
+            MofRangeVolumeProfile.GlobalHvnLevels.TryGetValue(instrument, out hvnList);
+            MofRangeVolumeProfile.GlobalLvnLevels.TryGetValue(instrument, out lvnList);
+
+            UpdateLines(hvnList ?? new List<double>(), "HVN", Brushes.Gold);
+            UpdateLines(lvnList ?? new List<double>(), "LVN", Brushes.Lime);
+        }
+
+        private void UpdateLines(List<double> levels, string prefix, Brush brush)
+        {
+            int decimals = (int)Math.Max(0, Math.Round(-Math.Log10(Instrument.MasterInstrument.TickSize)));
+            var desiredTags = new HashSet<string>(levels.Select(p => $"MOF_{prefix}_{Math.Round(p, decimals)}"));
+
+            foreach (var tag in currentTags.ToList())
+            {
+                if (!desiredTags.Contains(tag))
+                {
+                    RemoveDrawObject(tag);
+                    currentTags.Remove(tag);
+                }
+            }
+
+            foreach (double price in levels)
+            {
+                string tag = $"MOF_{prefix}_{Math.Round(price, decimals)}";
+                if (!currentTags.Contains(tag))
+                {
+                    var line = Draw.HorizontalLine(this, tag, price, brush);
+                    line.IsGlobalDrawingTool = true;
+                    line.IsLocked = true;
+                    currentTags.Add(tag);
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ dotnet build -c Release MyOrderFlowCustom.sln
 ```
 
 The resulting `MyOrderFlowCustom.dll` will be available in `bin/Release`.
+
+## Global HVN/LVN levels
+
+`MofRangeVolumeProfile` exposes the detected HVN and LVN levels through the
+static dictionaries `GlobalHvnLevels` and `GlobalLvnLevels`. An example
+indicator `MofGlobalLevelLines` reads these lists at each `OnBarUpdate` and
+draws global horizontal lines using `Draw.HorizontalLine`.
+
+To display the levels:
+
+1. Add a *Fixed Range Volume Profile* drawing on your chart.
+2. Enable **Use Global Levels** in its properties so the levels are exported.
+3. Add the `MOF Global Level Lines` indicator to the same instrument. It will
+   automatically create and remove the global lines as new levels are detected.


### PR DESCRIPTION
## Summary
- expose global HVN/LVN lists from `MofRangeVolumeProfile`
- remove drawing calls from `MofRangeVolumeProfile`
- add `MofGlobalLevelLines` indicator demonstrating how to draw global lines
- document how to connect the drawing tool and indicator

## Testing
- `dotnet build -c Release MyOrderFlowCustom.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0ca7f14c832cbee621299b265d45