### PR TITLE
Fix missing GlobalLevelLines indicator

### DIFF
--- a/MyOrderFlowCustom.csproj
+++ b/MyOrderFlowCustom.csproj
@@ -98,7 +98,8 @@
                 <Compile Include="Indicators\MyOrderFlowCustom\MofCumulativeDelta.cs" />
                 <Compile Include="Indicators\MyOrderFlowCustom\MofMarketDepth.cs" />
                 <Compile Include="Indicators\MyOrderFlowCustom\MofVolumeProfile.cs" />
+                <Compile Include="Indicators\MyOrderFlowCustom\MofGlobalLevelLines.cs" />
                 <Compile Include="Indicators\MyOrderFlowCustom\MofVWAP.cs" />
-		<Compile Include="InvestSoft\VolumeProfileUtils.cs" />
-	</ItemGroup>
+                <Compile Include="InvestSoft\VolumeProfileUtils.cs" />
+        </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- include `MofGlobalLevelLines.cs` in build

## Testing
- `dotnet build -c Release MyOrderFlowCustom.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0ff134a8832c8e1024ad0780bc0f