### PR TITLE
Fix assignment to read-only property in MofGlobalLevelLines

### DIFF
--- a/Indicators/MyOrderFlowCustom/MofGlobalLevelLines.cs
+++ b/Indicators/MyOrderFlowCustom/MofGlobalLevelLines.cs
@@ -67,8 +67,8 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                 string tag = $"MOF_{prefix}_{Math.Round(price, decimals)}";
                 if (!currentTags.Contains(tag))
                 {
-                    var line = Draw.HorizontalLine(this, tag, price, brush);
-                    line.IsGlobalDrawingTool = true;
+                    var line = Draw.HorizontalLine(this, tag, price, brush,
+                        DashStyleHelper.Solid, 1, true);
                     line.IsLocked = true;
                     currentTags.Add(tag);
                 }


### PR DESCRIPTION
## Summary
- fix horizontal line creation so global flag is passed via Draw helper

## Testing
- `dotnet build -c Release MyOrderFlowCustom.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c11a9f18c832cbd6161edc7cf685c