### PR TITLE
Fix horizontal line drawing

### DIFF
--- a/Indicators/MyOrderFlowCustom/MofGlobalLevelLines.cs
+++ b/Indicators/MyOrderFlowCustom/MofGlobalLevelLines.cs
@@ -77,7 +77,7 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                 if (!currentTags.Contains(tag))
                 {
                     var line = Draw.HorizontalLine(this, tag, price, stroke.Brush,
-                        stroke.StrokeStyle, stroke.Width, true);
+                        stroke.DashStyleHelper, (int)stroke.Width, true);
                     line.IsLocked = true;
                     currentTags.Add(tag);
                 }


### PR DESCRIPTION
## Summary
- fix argument types for Draw.HorizontalLine call

## Testing
- `dotnet build -c Release MyOrderFlowCustom.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c186db61c832c8bd3361b1d06cbd1