### PR TITLE
Improve HVN/LVN level detection

### DIFF
--- a/InvestSoft/VolumeProfileUtils.cs
+++ b/InvestSoft/VolumeProfileUtils.cs
@@ -384,4 +384,5 @@ namespace InvestSoft.NinjaScript.VolumeProfile
     public enum MofVolumeProfileMode { Standard, BuySell, Delta };
     public enum MofVolumeProfilePeriod { Sessions, Bars };
     public enum MofVolumeProfileResolution { Tick, Minute };
+    public enum PlateauSelectionMode { Lowest, Highest, Central };
 }


### PR DESCRIPTION
## Summary
- add enum `PlateauSelectionMode` to control plateau handling
- expose HVN and LVN plateau selection properties with defaults
- detect plateaus when scanning for HVN/LVN nodes and choose level using the new mode

## Testing
- `dotnet build MyOrderFlowCustom.csproj -v q` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c200b0344832ca4eaaf6c415e1a05