### PR TITLE
Highlight HVN/LVN detection zones

### DIFF
--- a/InvestSoft/VolumeProfileUtils.cs
+++ b/InvestSoft/VolumeProfileUtils.cs
@@ -189,20 +189,28 @@ namespace InvestSoft.NinjaScript.VolumeProfile
             return new SharpDX.RectangleF(xpos, ypos, barWidth, barHeight);
         }
 
-        internal void RenderProfile(MofVolumeProfileData profile, Brush volumeBrush)
+        internal void RenderProfile(MofVolumeProfileData profile, Brush volumeBrush,
+            Brush hvnBrush = null, Brush lvnBrush = null,
+            ISet<double> hvnZones = null, ISet<double> lvnZones = null)
         {
             foreach (KeyValuePair<double, MofVolumeProfileRow> row in profile)
             {
                 var rect = GetBarRect(profile, row.Key, row.Value.total);
+                Brush brush = volumeBrush;
+                if (hvnZones != null && hvnZones.Contains(row.Key))
+                    brush = hvnBrush ?? volumeBrush;
+                else if (lvnZones != null && lvnZones.Contains(row.Key))
+                    brush = lvnBrush ?? volumeBrush;
+
                 if (row.Key >= profile.VAL && row.Key <= profile.VAH)
                 {
-                    volumeBrush.Opacity = ValueAreaOpacity;
-                    renderTarget.FillRectangle(rect, volumeBrush);
+                    brush.Opacity = ValueAreaOpacity;
+                    renderTarget.FillRectangle(rect, brush);
                 }
                 else
                 {
-                    volumeBrush.Opacity = Opacity;
-                    renderTarget.FillRectangle(rect, volumeBrush);
+                    brush.Opacity = Opacity;
+                    renderTarget.FillRectangle(rect, brush);
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -26,4 +26,8 @@ To display the levels:
 3. Add the `MOF Global Level Lines` indicator to the same instrument. It will
    automatically create and remove the global lines as new levels are detected.
    You can now configure the HVN and LVN line styles and toggle their
-   visibility from the indicator properties.
+visibility from the indicator properties.
+
+The detection algorithm highlights bars that participate in HVN or LVN zones.
+Bars part of a local maximum are drawn in gold while bars that form a local
+minimum are drawn in blue.


### PR DESCRIPTION
## Summary
- add HVN/LVN highlight brushes to volume profile
- record HVN/LVN zones while detecting peaks
- color detection zone bars gold/blue
- hide plateau selection mode properties from UI
- document highlighting feature

## Testing
- `dotnet build -c Release MyOrderFlowCustom.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c32b76174832c8c571f91d118c3a2