### PR TITLE
Add imbalance detection with volume filter

### DIFF
--- a/InvestSoft/VolumeProfileUtils.cs
+++ b/InvestSoft/VolumeProfileUtils.cs
@@ -364,6 +364,24 @@ namespace InvestSoft.NinjaScript.VolumeProfile
             renderTarget.DrawTextLayout(position, textLayout, brush);
         }
 
+        internal void RenderBoldText(string text, SharpDX.Vector2 position, Brush brush, float maxWidth, TextAlignment align = TextAlignment.Leading)
+        {
+            var textLayout = new TextLayout(
+                NinjaTrader.Core.Globals.DirectWriteFactory,
+                text,
+                chartControl.Properties.LabelFont.ToDirectWriteTextFormat(),
+                maxWidth,
+                30
+            );
+            textLayout.TextAlignment = align;
+            textLayout.WordWrapping = WordWrapping.NoWrap;
+            var textWidth = textLayout.Metrics.Width;
+            if (textWidth > maxWidth) return;
+            var offset = new SharpDX.Vector2(position.X + 1, position.Y);
+            renderTarget.DrawTextLayout(offset, textLayout, brush);
+            renderTarget.DrawTextLayout(position, textLayout, brush);
+        }
+
         internal void RenderTotalVolume(MofVolumeProfileData profile, Brush textBrush)
         {
             var maxPrice = profile.Keys.Max();


### PR DESCRIPTION
## Summary
- implement imbalance ratio with volume filter for footprint chart
- highlight imbalances and absorptions on the chart
- support bold/highlighted text drawing

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6859c62c8820832ca9e5d2aa0ece1fd7