### PR TITLE
Fix footprint signal indexing

### DIFF
--- a/Indicators/MyOrderFlowCustom/MofFootrpint.cs
+++ b/Indicators/MyOrderFlowCustom/MofFootrpint.cs
@@ -94,10 +94,9 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                         signal = 1;
                     else if (profile.BidAbsorptions.Count > 0 || profile.StackedBidAbsorptions.Count > 0)
                         signal = -1;
-                    Values[0][1] = signal;
+                    Values[0][0] = signal;
                     profile = new MofFootprintBarData() { StartBar = CurrentBar, EndBar = CurrentBar };
                     Profiles.Add(profile);
-                    Values[0][0] = 0;
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- put the computed signal of the footprint indicator in the current bar value

## Testing
- `dotnet build -c Release MyOrderFlowCustom.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b110cd14c832c8674fda2972271be