### PR TITLE
Add HVN/LVN detection and bar outline color

### DIFF
--- a/Indicators/MyOrderFlowCustom/MofVolumeProfile.cs
+++ b/Indicators/MyOrderFlowCustom/MofVolumeProfile.cs
@@ -33,7 +33,13 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
         private SharpDX.Direct2D1.Brush volumeBrushDX;
         private SharpDX.Direct2D1.Brush buyBrushDX;
         private SharpDX.Direct2D1.Brush sellBrushDX;
+        private SharpDX.Direct2D1.Brush outlineBrushDX;
+        private SharpDX.Direct2D1.Brush hvnHighlightBrushDX;
+        private SharpDX.Direct2D1.Brush lvnHighlightBrushDX;
         private SharpDX.Direct2D1.Brush totalTextBrushDX;
+
+        private static readonly Dictionary<string, List<double>> globalHvnLevels = new Dictionary<string, List<double>>();
+        private static readonly Dictionary<string, List<double>> globalLvnLevels = new Dictionary<string, List<double>>();
 
         #region OnStateChange
         protected override void OnStateChange()
@@ -63,8 +69,20 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                 VolumeBrush = Brushes.CornflowerBlue;
                 BuyBrush = Brushes.DarkCyan;
                 SellBrush = Brushes.MediumVioletRed;
+                OutlineBrush = Brushes.Black;
                 PocStroke = new Stroke(Brushes.Goldenrod, 1);
                 ValueAreaStroke = new Stroke(Brushes.CornflowerBlue, DashStyleHelper.Dash, 1);
+                // HVN/LVN defaults
+                SmoothingWindow = 2;
+                NeighborBars = 2;
+                MinVolumePctOfPoc = 10;
+                MinDistanceTicks = 1;
+                MaxLevels = 5;
+                ShowHvn = true;
+                ShowLvn = true;
+                HvnStroke = new Stroke(Brushes.Yellow, DashStyleHelper.Dash, 1);
+                LvnStroke = new Stroke(Brushes.LawnGreen, DashStyleHelper.Dash, 1);
+                UseGlobalLevels = false;
             }
             else if (State == State.Configure)
             {
@@ -117,6 +135,12 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                 if (State == State.Realtime || IsFirstTickOfBar)
                 {
                     profile.CalculateValueArea(ValueArea / 100f);
+                    DetectLevels(profile);
+                    if (UseGlobalLevels)
+                    {
+                        globalHvnLevels[Instrument.FullName] = new List<double>(profile.HvnLevels);
+                        globalLvnLevels[Instrument.FullName] = new List<double>(profile.LvnLevels);
+                    }
                 }
 
                 // update profile end bar
@@ -133,11 +157,158 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                     if (State != State.Realtime)
                     {
                         profile.CalculateValueArea(ValueArea / 100f);
+                        DetectLevels(profile);
+                        if (UseGlobalLevels)
+                        {
+                            globalHvnLevels[Instrument.FullName] = new List<double>(profile.HvnLevels);
+                            globalLvnLevels[Instrument.FullName] = new List<double>(profile.LvnLevels);
+                        }
                     }
                     Profiles.Add(new MofVolumeProfileData() { StartBar = CurrentBar, EndBar = CurrentBar });
                 }
             }
         }
+        
+        private void DetectLevels(MofVolumeProfileData prof)
+        {
+            prof.HvnLevels.Clear();
+            prof.LvnLevels.Clear();
+            prof.HvnZones.Clear();
+            prof.LvnZones.Clear();
+            var prices = prof.Keys.OrderBy(p => p).ToList();
+            if (prices.Count == 0) return;
+            var vols = prices.Select(p => (double)prof[p].total).ToList();
+
+            int w = Math.Max(1, SmoothingWindow);
+            List<double> smooth = new List<double>(prices.Count);
+            for (int i = 0; i < prices.Count; i++)
+            {
+                int s = Math.Max(0, i - w);
+                int e = Math.Min(prices.Count - 1, i + w);
+                double sum = 0;
+                for (int j = s; j <= e; j++) sum += vols[j];
+                smooth.Add(sum / (e - s + 1));
+            }
+
+            int n = Math.Max(1, NeighborBars);
+            double minVol = prof.ContainsKey(prof.POC) ? prof[prof.POC].total * (MinVolumePctOfPoc / 100.0) : 0;
+            double tick = Instrument.MasterInstrument.TickSize;
+
+            const double EPS = 1e-8;
+            for (int i = 0; i < prices.Count; )
+            {
+                int start = i;
+                int end = i;
+                while (end + 1 < prices.Count && Math.Abs(smooth[end + 1] - smooth[end]) < EPS)
+                    end++;
+
+                double v = smooth[i];
+                bool higher = true;
+                bool lower = true;
+                for (int k = 1; k <= n; k++)
+                {
+                    if (start - k >= 0)
+                    {
+                        if (smooth[start - k] >= v) higher = false;
+                        if (smooth[start - k] <= v) lower = false;
+                    }
+                    if (end + k < prices.Count)
+                    {
+                        if (smooth[end + k] >= v) higher = false;
+                        if (smooth[end + k] <= v) lower = false;
+                    }
+                }
+
+                if (higher && v >= minVol)
+                {
+                    for (int j = start; j <= end; j++)
+                        prof.HvnZones.Add(prices[j]);
+                    int idx = GetPlateauIndex(start, end, vols, true, PlateauSelectionMode.Central);
+                    int extremeIdx = idx;
+                    double extremeVol = vols[idx];
+                    for (int j = 1; j <= n; j++)
+                    {
+                        int left = idx - j;
+                        if (left >= 0 && vols[left] > extremeVol)
+                        {
+                            extremeVol = vols[left];
+                            extremeIdx = left;
+                        }
+                        int right = idx + j;
+                        if (right < vols.Count && vols[right] > extremeVol)
+                        {
+                            extremeVol = vols[right];
+                            extremeIdx = right;
+                        }
+                    }
+                    double price = prices[extremeIdx];
+                    if (prof.HvnLevels.All(p => Math.Abs(p - price) > tick * MinDistanceTicks))
+                        prof.HvnLevels.Add(price);
+                }
+                if (lower)
+                {
+                    for (int j = start; j <= end; j++)
+                        prof.LvnZones.Add(prices[j]);
+                    int idx = GetPlateauIndex(start, end, vols, false, PlateauSelectionMode.Central);
+                    int extremeIdx = idx;
+                    double extremeVol = vols[idx];
+                    for (int j = 1; j <= n; j++)
+                    {
+                        int left = idx - j;
+                        if (left >= 0 && vols[left] < extremeVol)
+                        {
+                            extremeVol = vols[left];
+                            extremeIdx = left;
+                        }
+                        int right = idx + j;
+                        if (right < vols.Count && vols[right] < extremeVol)
+                        {
+                            extremeVol = vols[right];
+                            extremeIdx = right;
+                        }
+                    }
+                    double price = prices[extremeIdx];
+                    if (prof.LvnLevels.All(p => Math.Abs(p - price) > tick * MinDistanceTicks))
+                        prof.LvnLevels.Add(price);
+                }
+
+                i = end + 1;
+            }
+
+            prof.HvnLevels = prof.HvnLevels.OrderByDescending(p => prof[p].total).Take(MaxLevels).ToList();
+            prof.LvnLevels = prof.LvnLevels.OrderBy(p => prof[p].total).Take(MaxLevels).ToList();
+        }
+
+        private int GetPlateauIndex(int start, int end, List<double> vols, bool chooseMax, PlateauSelectionMode mode)
+        {
+            double extreme = vols[start];
+            List<int> indices = new List<int> { start };
+            for (int i = start + 1; i <= end; i++)
+            {
+                double vv = vols[i];
+                if (chooseMax ? vv > extreme : vv < extreme)
+                {
+                    extreme = vv;
+                    indices.Clear();
+                    indices.Add(i);
+                }
+                else if (vv == extreme)
+                {
+                    indices.Add(i);
+                }
+            }
+
+            switch (mode)
+            {
+                case PlateauSelectionMode.Highest:
+                    return indices[indices.Count - 1];
+                case PlateauSelectionMode.Central:
+                    return indices[indices.Count / 2];
+                default:
+                    return indices[0];
+            }
+        }
+
         #endregion
 
         #region Rendering
@@ -148,7 +319,8 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
             {
                 Opacity = Opacity / 100f,
                 ValueAreaOpacity = ValueAreaOpacity / 100f,
-                WidthPercent = Width / 100f
+                WidthPercent = Width / 100f,
+                OutlineBrush = outlineBrushDX
             };
             totalTextBrushDX = chartControl.Properties.ChartText.ToDxBrush(RenderTarget);
             foreach (var profile in Profiles)
@@ -164,10 +336,21 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                 }
                 else
                 {
-                    volProfileRenderer.RenderProfile(profile, volumeBrushDX);
+                    volProfileRenderer.RenderProfile(
+                        profile,
+                        volumeBrushDX,
+                        hvnHighlightBrushDX,
+                        lvnHighlightBrushDX,
+                        profile.HvnZones,
+                        profile.LvnZones
+                    );
                 }
                 if (ShowPoc) volProfileRenderer.RenderPoc(profile, PocStroke.BrushDX, PocStroke.Width, PocStroke.StrokeStyle, DisplayTotal);
                 if (ShowValueArea) volProfileRenderer.RenderValueArea(profile, ValueAreaStroke.BrushDX, ValueAreaStroke.Width, ValueAreaStroke.StrokeStyle, DisplayTotal);
+                if (ShowHvn && profile.HvnLevels.Count > 0)
+                    volProfileRenderer.RenderLevels(profile, profile.HvnLevels, HvnStroke.BrushDX, HvnStroke.Width, HvnStroke.StrokeStyle);
+                if (ShowLvn && profile.LvnLevels.Count > 0)
+                    volProfileRenderer.RenderLevels(profile, profile.LvnLevels, LvnStroke.BrushDX, LvnStroke.Width, LvnStroke.StrokeStyle);
                 if (DisplayMode == MofVolumeProfileMode.Delta)
                 {
                     volProfileRenderer.RenderDeltaProfile(profile, buyBrushDX, sellBrushDX);
@@ -184,13 +367,21 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
             if (volumeBrushDX != null) volumeBrushDX.Dispose();
             if (buyBrushDX != null) buyBrushDX.Dispose();
             if (sellBrushDX != null) sellBrushDX.Dispose();
+            if (outlineBrushDX != null) outlineBrushDX.Dispose();
+            if (hvnHighlightBrushDX != null) hvnHighlightBrushDX.Dispose();
+            if (lvnHighlightBrushDX != null) lvnHighlightBrushDX.Dispose();
             if (RenderTarget != null)
             {
                 volumeBrushDX = VolumeBrush.ToDxBrush(RenderTarget);
                 buyBrushDX = BuyBrush.ToDxBrush(RenderTarget);
                 sellBrushDX = SellBrush.ToDxBrush(RenderTarget);
+                outlineBrushDX = OutlineBrush.ToDxBrush(RenderTarget);
+                hvnHighlightBrushDX = Brushes.Gold.ToDxBrush(RenderTarget);
+                lvnHighlightBrushDX = Brushes.Blue.ToDxBrush(RenderTarget);
                 PocStroke.RenderTarget = RenderTarget;
                 ValueAreaStroke.RenderTarget = RenderTarget;
+                HvnStroke.RenderTarget = RenderTarget;
+                LvnStroke.RenderTarget = RenderTarget;
             }
         }
         #endregion
@@ -270,12 +461,56 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
             set { SellBrush = Serialize.StringToBrush(value); }
         }
 
+        [XmlIgnore]
+        [Display(Name = "Color for outline", Order = 13, GroupName = "Visual")]
+        public Brush OutlineBrush { get; set; }
+
+        [Browsable(false)]
+        public string OutlineBrushSerialize
+        {
+            get { return Serialize.BrushToString(OutlineBrush); }
+            set { OutlineBrush = Serialize.StringToBrush(value); }
+        }
+
         // Lines
         [Display(Name = "POC", Order = 8, GroupName = "Lines")]
         public Stroke PocStroke { get; set; }
 
         [Display(Name = "Value Area", Order = 9, GroupName = "Lines")]
         public Stroke ValueAreaStroke { get; set; }
+
+        [Display(Name = "HVN", Order = 10, GroupName = "Lines")]
+        public Stroke HvnStroke { get; set; }
+
+        [Display(Name = "LVN", Order = 11, GroupName = "Lines")]
+        public Stroke LvnStroke { get; set; }
+
+        [Display(Name = "Show HVN", Order = 12, GroupName = "Lines")]
+        public bool ShowHvn { get; set; }
+
+        [Display(Name = "Show LVN", Order = 13, GroupName = "Lines")]
+        public bool ShowLvn { get; set; }
+
+        [Range(1, 20)]
+        [Display(Name = "Smoothing Window", Order = 1, GroupName = "Levels")]
+        public int SmoothingWindow { get; set; }
+
+        [Range(1, 20)]
+        [Display(Name = "Neighbor Bars", Order = 2, GroupName = "Levels")]
+        public int NeighborBars { get; set; }
+
+        [Range(0, 100)]
+        [Display(Name = "Min Vol % of POC", Order = 3, GroupName = "Levels")]
+        public int MinVolumePctOfPoc { get; set; }
+
+        [Display(Name = "Min Distance (ticks)", Order = 5, GroupName = "Levels")]
+        public int MinDistanceTicks { get; set; }
+
+        [Display(Name = "Max Levels", Order = 6, GroupName = "Levels")]
+        public int MaxLevels { get; set; }
+
+        [Display(Name = "Use Global Levels", Order = 7, GroupName = "Levels")]
+        public bool UseGlobalLevels { get; set; }
         #endregion
     }
 }

--- a/InvestSoft/VolumeProfileUtils.cs
+++ b/InvestSoft/VolumeProfileUtils.cs
@@ -37,6 +37,11 @@ namespace InvestSoft.NinjaScript.VolumeProfile
         public double VAL { get; set; }
         public double POC { get; set; }
 
+        public List<double> HvnLevels { get; set; } = new List<double>();
+        public List<double> LvnLevels { get; set; } = new List<double>();
+        public HashSet<double> HvnZones { get; set; } = new HashSet<double>();
+        public HashSet<double> LvnZones { get; set; } = new HashSet<double>();
+
         public MofVolumeProfileRow UpdateRow(double price, long buyVolume, long sellVolume, long otherVolume)
         {
             var row = AddOrUpdate(
@@ -137,6 +142,7 @@ namespace InvestSoft.NinjaScript.VolumeProfile
         public float Opacity { get; set; }
         public float ValueAreaOpacity { get; set; }
         public float WidthPercent;
+        public Brush OutlineBrush { get; set; }
 
         public MofVolumeProfileChartRenderer(
             ChartControl chartControl, ChartScale chartScale, ChartBars chartBars,
@@ -202,15 +208,13 @@ namespace InvestSoft.NinjaScript.VolumeProfile
                 else if (lvnZones != null && lvnZones.Contains(row.Key))
                     brush = lvnBrush ?? volumeBrush;
 
-                if (row.Key >= profile.VAL && row.Key <= profile.VAH)
+                bool inVa = row.Key >= profile.VAL && row.Key <= profile.VAH;
+                brush.Opacity = inVa ? ValueAreaOpacity : Opacity;
+                renderTarget.FillRectangle(rect, brush);
+                if (OutlineBrush != null)
                 {
-                    brush.Opacity = ValueAreaOpacity;
-                    renderTarget.FillRectangle(rect, brush);
-                }
-                else
-                {
-                    brush.Opacity = Opacity;
-                    renderTarget.FillRectangle(rect, brush);
+                    OutlineBrush.Opacity = brush.Opacity;
+                    renderTarget.DrawRectangle(rect, OutlineBrush);
                 }
             }
         }
@@ -301,6 +305,12 @@ namespace InvestSoft.NinjaScript.VolumeProfile
                 }
                 renderTarget.FillRectangle(buyRect, buyBrush);
                 renderTarget.FillRectangle(sellRect, sellBrush);
+                if (OutlineBrush != null)
+                {
+                    OutlineBrush.Opacity = buyBrush.Opacity;
+                    renderTarget.DrawRectangle(buyRect, OutlineBrush);
+                    renderTarget.DrawRectangle(sellRect, OutlineBrush);
+                }
             }
         }
 
@@ -323,6 +333,11 @@ namespace InvestSoft.NinjaScript.VolumeProfile
                 renderTarget.FillRectangle(
                     rect, (row.Value.buy > row.Value.sell) ? buyBrush : sellBrush
                 );
+                if (OutlineBrush != null)
+                {
+                    OutlineBrush.Opacity = buyBrush.Opacity;
+                    renderTarget.DrawRectangle(rect, OutlineBrush);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- support drawing bar outlines via new `OutlineBrush`
- detect HVN/LVN in volume profile indicator similar to drawing tool
- render HVN/LVN levels and highlight zones

## Testing
- `dotnet build -c Release MyOrderFlowCustom.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878e241b7d8832c8383520d43bcbe0f