### PR TITLE
Highlight bars based on HVN/LVN lines

### DIFF
--- a/Indicators/MyOrderFlowCustom/MofVolumeProfile.cs
+++ b/Indicators/MyOrderFlowCustom/MofVolumeProfile.cs
@@ -341,8 +341,8 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                         volumeBrushDX,
                         hvnHighlightBrushDX,
                         lvnHighlightBrushDX,
-                        profile.HvnZones,
-                        profile.LvnZones
+                        new HashSet<double>(profile.HvnLevels),
+                        new HashSet<double>(profile.LvnLevels)
                     );
                 }
                 if (ShowPoc) volProfileRenderer.RenderPoc(profile, PocStroke.BrushDX, PocStroke.Width, PocStroke.StrokeStyle, DisplayTotal);
@@ -376,12 +376,12 @@ namespace NinjaTrader.NinjaScript.Indicators.MyOrderFlowCustom
                 buyBrushDX = BuyBrush.ToDxBrush(RenderTarget);
                 sellBrushDX = SellBrush.ToDxBrush(RenderTarget);
                 outlineBrushDX = OutlineBrush.ToDxBrush(RenderTarget);
-                hvnHighlightBrushDX = Brushes.Gold.ToDxBrush(RenderTarget);
-                lvnHighlightBrushDX = Brushes.Blue.ToDxBrush(RenderTarget);
                 PocStroke.RenderTarget = RenderTarget;
                 ValueAreaStroke.RenderTarget = RenderTarget;
                 HvnStroke.RenderTarget = RenderTarget;
                 LvnStroke.RenderTarget = RenderTarget;
+                hvnHighlightBrushDX = HvnStroke.Brush.ToDxBrush(RenderTarget);
+                lvnHighlightBrushDX = LvnStroke.Brush.ToDxBrush(RenderTarget);
             }
         }
         #endregion


### PR DESCRIPTION
## Summary
- highlight profile bars only at HVN/LVN levels
- use the same color for highlighted bars as the HVN/LVN line strokes

## Testing
- `xbuild MyOrderFlowCustom.sln` *(fails: default XML namespace must be MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6878f3fbf87c832c884a175e6660bcef